### PR TITLE
Round up mapping length in mprotect

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -36,7 +36,7 @@
 
 DIRNAME=$(dirname $0)
 
-bench_version=0.4.1-rh.31
+bench_version=0.4.1-rh.32
 libmicro_version=`$DIRNAME/bin/tattle -V`
 
 case $libmicro_version in

--- a/libmicro.h
+++ b/libmicro.h
@@ -34,7 +34,7 @@
 
 #include <pthread.h>
 
-#define	LIBMICRO_VERSION	"0.4.1-rh.31"
+#define	LIBMICRO_VERSION	"0.4.1-rh.32"
 
 #define	STRSIZE	1024
 

--- a/mprotect.c
+++ b/mprotect.c
@@ -127,6 +127,9 @@ benchmark_initrun(void)
 	int	flags;
 	int	i;
 
+	// Round mapping length up to first higher multiple of page size
+	optl = (optl + pagesize - 1) / pagesize * pagesize;
+
 	if (!anon) {
 		fd = open(optf, O_RDWR);
         if (fd < 0) {

--- a/suites/verify_names.py
+++ b/suites/verify_names.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #
 # Copyright 2012 Red Hat, Inc.


### PR DESCRIPTION
In mprotect benchmark added rounding of mapping-length parameter to nearest bigger multiple of pagesize to prevent improper call of mprotect and possible crash.
This issue lead to segfault of benchmark on ppc64le architecture with cpu-partitioning tuned profile.